### PR TITLE
docs: expand constitution and guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,21 @@
 
 This file provides comprehensive guidance to Claude Code for maintaining context, preventing spaghetti code, and orchestrating complex software development using advanced context engineering principles.
 
+## 📜 Operating Constitution
+- `.claude/commands`: reusable slash commands
+- `.claude/agents`: specialized subagents (see docs/subagents.md)
+- `.claude/hooks`: automation hooks
+- `.mcp.json`: configure external MCP servers (see docs/mcp-servers.md)
+- `docs/`: engineering guides and rule templates
+  - `context-engineering.md`
+  - `subagents.md`
+  - `claude-templates.md`
+
+## 🗃️ Nested Rules Files
+- Directories may define their own `CLAUDE.md` to scope rules.
+- Use `See: @../CLAUDE.md` to inherit parent guidance.
+- Templates are available in `docs/claude-templates.md`.
+
 ## 🧠 Core Principles
 
 ### Context Over Everything
@@ -106,6 +121,21 @@ src/
 - **Duplication**: Less than 3% code duplication
 
 ## 🔄 Development Workflow
+
+### Core Cycle
+1. **Explore** – gather context and read relevant files
+2. **Plan** – outline steps or use Plan mode (`Shift+Tab` twice)
+3. **Code** – implement small, testable changes
+4. **Commit** – run tests, update docs, and commit
+
+### Test-Driven Development
+1. Write or update tests first
+2. Run `/test-all`
+3. Implement code to satisfy tests
+
+### Additional Workflows
+- Screenshot iteration for UI tweaks
+- Codebase Q&A and onboarding for new contributors
 
 ### Pre-Implementation Phase (Ultra-Think)
 1. **Context Loading**: Load relevant files and patterns
@@ -361,6 +391,12 @@ After each task:
 - `/find-patterns`: Identify reusable patterns
 - `/check-quality`: Run quality metrics
 - `/security-scan`: Security vulnerability check
+
+## 🔒 Security & Quality
+- Act as a security-conscious developer; treat all code as untrusted until validated
+- Run `/security-scan` and `/check-quality` after significant changes
+- Follow language-specific secure coding practices
+- Prefer least-privilege commands and confirm destructive actions
 
 ## 🚀 Performance Guidelines
 

--- a/docs/claude-templates.md
+++ b/docs/claude-templates.md
@@ -1,0 +1,40 @@
+# CLAUDE.md Templates
+
+Use these templates as starting points for global and directory-specific rules files. Remember that deeper `CLAUDE.md` files override parent rules within their scope.
+
+## Root `CLAUDE.md`
+
+```markdown
+# CLAUDE.md
+
+## Core Principles
+- Context over everything
+- Test after every change
+- Document while coding
+
+## Commands
+- `/scan-project` – map structure and dependencies
+- `/test-all` – run full test suite
+- `/security-scan` – check for vulnerabilities
+
+## Workflow
+1. Explore → Plan → Code → Commit
+2. Run tests and linters
+3. Update docs and memory
+```
+
+## Directory `CLAUDE.md`
+
+```markdown
+# CLAUDE.md – frontend/
+See: @../CLAUDE.md
+
+## Additional Rules
+- Follow React and TypeScript style guides
+- Keep components under 200 lines
+- Add snapshots for new UI
+```
+
+## Private Instructions
+
+Create a `CLAUDE.local.md` (git-ignored) for secrets or machine-specific paths. The agent will merge it with the visible rules at runtime.

--- a/docs/mcp-servers.md
+++ b/docs/mcp-servers.md
@@ -1,0 +1,30 @@
+# MCP Server Integration
+
+Claude Code can connect to external Model Context Protocol (MCP) servers for up-to-date knowledge and advanced tooling. Configure servers in an `.mcp.json` file at the project root.
+
+## Example Configuration
+
+```json
+{
+  "servers": {
+    "context7": {
+      "url": "https://context7.anthropic.com",
+      "apiKey": "$CONTEXT7_API_KEY"
+    },
+    "sequential": {
+      "url": "https://sequential.example.com",
+      "apiKey": "$SEQUENTIAL_API_KEY"
+    }
+  }
+}
+```
+
+Store API keys as environment variables, not in the config file.
+
+## Usage
+
+1. Ensure the server entries exist in `.mcp.json`.
+2. Reference commands or docs provided by the server within your prompts.
+3. Use `/clear-context` and `/load-context` when switching between projects that require different servers.
+
+For custom setups, consult the provider's documentation or create project-specific instructions in a local rules file.

--- a/docs/subagents.md
+++ b/docs/subagents.md
@@ -1,0 +1,43 @@
+# Subagent Architecture Guide
+
+Claude Code OS uses specialized subagents to handle complex or parallelizable tasks. These agents live in `.claude/agents` and can be activated on demand to extend the main agent's capabilities.
+
+## Existing Subagents
+
+| Agent | Purpose |
+|-------|---------|
+| `context-analyzer.md` | Maps project structure, dependencies and patterns |
+| `implementation-engineer.md` | Generates code following established conventions |
+| `test-automation.md` | Writes and runs tests, reports coverage |
+
+## Design Principles
+
+1. **Single Responsibility** – Each subagent owns a well-defined domain.
+2. **Minimal Context** – Provide only the files and instructions needed for the task.
+3. **Explicit Interfaces** – Tasks and responses follow a clear contract:
+   ```yaml
+   input:
+     task: "<what to do>"
+     context: "<relevant files>"
+   output:
+     status: success|failure|partial
+     result: "<primary result>"
+     notes: ["<follow-up actions>"]
+   ```
+4. **Memory Integration** – Persist useful discoveries via `/save-context`.
+5. **Security First** – Subagents should follow the same security checks as the main agent.
+
+## Creating a New Subagent
+
+1. Add a markdown file in `.claude/agents` describing the agent's role and protocols.
+2. Reference the agent from `CLAUDE.md` or a custom command.
+3. Keep files under 300 lines and document expectations, inputs and outputs.
+
+## Activation Workflow
+
+1. Main agent performs high-level planning.
+2. Delegate scoped tasks to subagents in parallel.
+3. Aggregate results and reconcile conflicts.
+4. Persist new knowledge to memory and update documentation.
+
+For more on context orchestration, see `docs/context-engineering.md`.


### PR DESCRIPTION
## Summary
- expand root CLAUDE.md with tooling map, nested rule guidance, workflow cycle and security notes
- document subagent architecture, rule file templates and MCP server setup

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a8649392c832188112394eaa627c4